### PR TITLE
Fix for fontawesome import that wouldn’t compile

### DIFF
--- a/CBFormController/Classes/CBFormItem.h
+++ b/CBFormController/Classes/CBFormItem.h
@@ -6,7 +6,7 @@
 //
 //
 
-@import FontAwesome;
+#import <FontAwesome/NSString+FontAwesome.h>
 #import <Foundation/Foundation.h>
 #import "CBCell.h"
 


### PR DESCRIPTION
The changes made in 0.3.3 wouldn't compile for me. It said Module 'FontAwesome' not found on the import in CBFormItem.h. 

Switching to an #import fixed it for me. If there was a reason you guys needed to be an @import instead of #import, then please resolve this such that it will build, or let me know if I'm just doing something stupid.